### PR TITLE
fix(frontend): resolve currency display and session state isolation bugs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,20 @@
+# Architecture & State Management
+
+## User Preferences (Currency & Language)
+
+### Source of Truth
+- **Authenticated User:** The **Backend** is the single source of truth.
+  - Upon login, the frontend MUST fetch the user's profile to determine the correct `currency` and `language`.
+  - `localStorage` values should be ignored or overwritten by backend data when a valid user session exists.
+- **Guest/Unauthenticated:** `localStorage` is used as a fallback to persist preferences across sessions for non-logged users (if applicable).
+
+### State Synchronization Rules
+1. **Login:** Fetch profile -> Update Contexts -> Update `localStorage`.
+2. **Logout:** Clear `localStorage` (tokens and preferences) -> Reset Contexts.
+3. **Update:** Optimistic update in Context -> Send request to Backend -> Update `localStorage`.
+
+### Security & Cleanup
+- On **Logout**, the application MUST:
+  - Invalidate all React Query caches (`queryClient.clear()`).
+  - Clear sensitive data from `localStorage` (`access_token`).
+  - Clear user preferences from `localStorage` to prevent information leakage between sessions.

--- a/apps/backend/src/application/application.module.ts
+++ b/apps/backend/src/application/application.module.ts
@@ -14,6 +14,8 @@ import { ListCategoriesUseCase } from './use-cases/categories/list-categories.us
 import { UpdateCategoryUseCase } from './use-cases/categories/update-category.use-case';
 import { DeleteCategoryUseCase } from './use-cases/categories/delete-category.use-case';
 import { UpdateUserCurrencyUseCase } from './use-cases/user/update-user-currency.use-case';
+import { UpdateUserProfileUseCase } from './use-cases/user/update-user-profile.use-case';
+import { GetUserProfileUseCase } from './use-cases/user/get-user-profile.use-case';
 
 @Module({
   imports: [InfrastructureModule],
@@ -32,6 +34,8 @@ import { UpdateUserCurrencyUseCase } from './use-cases/user/update-user-currency
     UpdateCategoryUseCase,
     DeleteCategoryUseCase,
     UpdateUserCurrencyUseCase,
+    UpdateUserProfileUseCase,
+    GetUserProfileUseCase,
     GetExpenseCountsByPeriodUseCase,
   ],
   exports: [
@@ -48,6 +52,8 @@ import { UpdateUserCurrencyUseCase } from './use-cases/user/update-user-currency
     UpdateCategoryUseCase,
     DeleteCategoryUseCase,
     UpdateUserCurrencyUseCase,
+    UpdateUserProfileUseCase,
+    GetUserProfileUseCase,
     GetExpenseCountsByPeriodUseCase,
   ],
 })

--- a/apps/backend/src/application/use-cases/expenses/list-expenses.use-case.ts
+++ b/apps/backend/src/application/use-cases/expenses/list-expenses.use-case.ts
@@ -32,7 +32,7 @@ export class ListExpensesUseCase {
     @Inject(USER_REPOSITORY)
     private readonly userRepository: any,
     private readonly exchangeRateService: ExchangeRateService,
-  ) { }
+  ) {}
 
   async execute(query: ListExpensesQuery): Promise<ListExpensesResult> {
     const user = await this.userRepository.findById(query.userId);

--- a/apps/backend/src/application/use-cases/expenses/list-expenses.use-case.ts
+++ b/apps/backend/src/application/use-cases/expenses/list-expenses.use-case.ts
@@ -32,7 +32,7 @@ export class ListExpensesUseCase {
     @Inject(USER_REPOSITORY)
     private readonly userRepository: any,
     private readonly exchangeRateService: ExchangeRateService,
-  ) {}
+  ) { }
 
   async execute(query: ListExpensesQuery): Promise<ListExpensesResult> {
     const user = await this.userRepository.findById(query.userId);
@@ -64,6 +64,20 @@ export class ListExpensesUseCase {
 
     const convertedExpenses = result.data.map((expense) => {
       if (expense.originalCurrency === targetCurrency) {
+        if (expense.amount !== expense.originalAmount) {
+          return new Expense(
+            expense.id,
+            expense.userId,
+            expense.description,
+            expense.originalAmount,
+            expense.date,
+            expense.category,
+            expense.originalAmount,
+            expense.originalCurrency,
+            expense.createdAt,
+            expense.updatedAt,
+          );
+        }
         return expense;
       }
       const rate = rates[expense.originalCurrency];

--- a/apps/backend/src/application/use-cases/user/get-user-profile.use-case.ts
+++ b/apps/backend/src/application/use-cases/user/get-user-profile.use-case.ts
@@ -1,0 +1,15 @@
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../../../domain/repositories/user.repository.interface';
+import { User } from '../../../domain/entities/user.entity';
+
+@Injectable()
+export class GetUserProfileUseCase {
+  constructor(@Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository) {}
+
+  async execute(userId: string): Promise<User | null> {
+    return await this.userRepository.findById(userId);
+  }
+}

--- a/apps/backend/src/application/use-cases/user/update-user-profile.use-case.ts
+++ b/apps/backend/src/application/use-cases/user/update-user-profile.use-case.ts
@@ -1,0 +1,48 @@
+
+import { Injectable, Inject } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '../../../domain/repositories/user.repository.interface';
+import { User } from '../../../domain/entities/user.entity';
+import { UpdateUserCurrencyUseCase } from './update-user-currency.use-case';
+
+export interface UpdateUserProfileInput {
+    userId: string;
+    name?: string;
+    currency?: string;
+    language?: string;
+}
+
+@Injectable()
+export class UpdateUserProfileUseCase {
+    constructor(
+        @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+        private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase
+    ) { }
+
+    async execute(input: UpdateUserProfileInput): Promise<User> {
+        let user: User | null = null;
+
+
+        if (input.currency) {
+            user = await this.updateUserCurrencyUseCase.execute({
+                userId: input.userId,
+                newCurrency: input.currency
+            });
+        }
+
+        const updates: { name?: string; language?: string } = {};
+        if (input.name) updates.name = input.name;
+        if (input.language) updates.language = input.language;
+
+        if (Object.keys(updates).length > 0) {
+            user = await this.userRepository.update(input.userId, updates);
+        }
+
+        if (!user) {
+            const foundUser = await this.userRepository.findById(input.userId);
+            if (!foundUser) throw new Error('User not found');
+            return foundUser;
+        }
+
+        return user;
+    }
+}

--- a/apps/backend/src/application/use-cases/user/update-user-profile.use-case.ts
+++ b/apps/backend/src/application/use-cases/user/update-user-profile.use-case.ts
@@ -1,48 +1,49 @@
-
 import { Injectable, Inject } from '@nestjs/common';
-import { IUserRepository, USER_REPOSITORY } from '../../../domain/repositories/user.repository.interface';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../../../domain/repositories/user.repository.interface';
 import { User } from '../../../domain/entities/user.entity';
 import { UpdateUserCurrencyUseCase } from './update-user-currency.use-case';
 
 export interface UpdateUserProfileInput {
-    userId: string;
-    name?: string;
-    currency?: string;
-    language?: string;
+  userId: string;
+  name?: string;
+  currency?: string;
+  language?: string;
 }
 
 @Injectable()
 export class UpdateUserProfileUseCase {
-    constructor(
-        @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
-        private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase
-    ) { }
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+    private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase,
+  ) {}
 
-    async execute(input: UpdateUserProfileInput): Promise<User> {
-        let user: User | null = null;
+  async execute(input: UpdateUserProfileInput): Promise<User> {
+    let user: User | null = null;
 
-
-        if (input.currency) {
-            user = await this.updateUserCurrencyUseCase.execute({
-                userId: input.userId,
-                newCurrency: input.currency
-            });
-        }
-
-        const updates: { name?: string; language?: string } = {};
-        if (input.name) updates.name = input.name;
-        if (input.language) updates.language = input.language;
-
-        if (Object.keys(updates).length > 0) {
-            user = await this.userRepository.update(input.userId, updates);
-        }
-
-        if (!user) {
-            const foundUser = await this.userRepository.findById(input.userId);
-            if (!foundUser) throw new Error('User not found');
-            return foundUser;
-        }
-
-        return user;
+    if (input.currency) {
+      user = await this.updateUserCurrencyUseCase.execute({
+        userId: input.userId,
+        newCurrency: input.currency,
+      });
     }
+
+    const updates: { name?: string; language?: string } = {};
+    if (input.name) updates.name = input.name;
+    if (input.language) updates.language = input.language;
+
+    if (Object.keys(updates).length > 0) {
+      user = await this.userRepository.update(input.userId, updates);
+    }
+
+    if (!user) {
+      const foundUser = await this.userRepository.findById(input.userId);
+      if (!foundUser) throw new Error('User not found');
+      return foundUser;
+    }
+
+    return user;
+  }
 }

--- a/apps/backend/src/domain/entities/user.entity.ts
+++ b/apps/backend/src/domain/entities/user.entity.ts
@@ -5,6 +5,7 @@ export class User {
     public readonly passwordHash: string,
     public readonly name: string,
     public readonly currency: string = 'BRL',
+    public readonly language: string = 'pt',
     public readonly createdAt: Date = new Date(),
   ) {
     this.validateEmail(email);

--- a/apps/backend/src/infrastructure/database/mongodb/repositories/user-mongodb.repository.ts
+++ b/apps/backend/src/infrastructure/database/mongodb/repositories/user-mongodb.repository.ts
@@ -18,6 +18,7 @@ export class UserMongodbRepository implements IUserRepository {
       passwordHash: user.passwordHash,
       name: user.name,
       currency: user.currency,
+      language: user.language,
     });
 
     const saved = await userDoc.save();
@@ -62,6 +63,7 @@ export class UserMongodbRepository implements IUserRepository {
       userDoc.passwordHash,
       userDoc.name,
       userDoc.currency || 'BRL',
+      userDoc.language || 'pt',
       userDoc.createdAt || new Date(),
     );
   }

--- a/apps/backend/src/infrastructure/database/mongodb/schemas/user.schema.ts
+++ b/apps/backend/src/infrastructure/database/mongodb/schemas/user.schema.ts
@@ -20,6 +20,9 @@ export class UserSchema {
 
   @Prop({ required: true, default: 'BRL', minlength: 3, maxlength: 3 })
   currency!: string;
+
+  @Prop({ required: true, default: 'pt', minlength: 2, maxlength: 2 })
+  language!: string;
 }
 
 export const UserMongooseSchema = SchemaFactory.createForClass(UserSchema);

--- a/apps/backend/src/presentation/controllers/dtos/update-user-profile.dto.ts
+++ b/apps/backend/src/presentation/controllers/dtos/update-user-profile.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional, Length, MinLength, MaxLength } from 'class-validator';
+
+export class UpdateUserProfileDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(3, 3)
+  currency?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(2, 2)
+  language?: string;
+}

--- a/apps/backend/src/presentation/controllers/user.controller.ts
+++ b/apps/backend/src/presentation/controllers/user.controller.ts
@@ -22,7 +22,7 @@ export class UserController {
     private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase,
     private readonly updateUserProfileUseCase: UpdateUserProfileUseCase,
     private readonly getUserProfileUseCase: GetUserProfileUseCase,
-  ) { }
+  ) {}
 
   @Get('profile')
   @ApiOperation({ summary: 'Get user profile' })

--- a/apps/backend/src/presentation/controllers/user.controller.ts
+++ b/apps/backend/src/presentation/controllers/user.controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Patch, Body, Request, UseGuards } from '@nestjs/common';
+import { Controller, Patch, Body, Request, UseGuards, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { UpdateUserCurrencyUseCase } from '../../application/use-cases/user/update-user-currency.use-case';
+import { UpdateUserProfileUseCase } from '../../application/use-cases/user/update-user-profile.use-case';
+import { GetUserProfileUseCase } from '../../application/use-cases/user/get-user-profile.use-case';
 import { IsString, Length } from 'class-validator';
+import { UpdateUserProfileDto } from './dtos/update-user-profile.dto';
 
 class UpdateCurrencyDto {
   @IsString()
@@ -15,7 +18,51 @@ class UpdateCurrencyDto {
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 export class UserController {
-  constructor(private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase) {}
+  constructor(
+    private readonly updateUserCurrencyUseCase: UpdateUserCurrencyUseCase,
+    private readonly updateUserProfileUseCase: UpdateUserProfileUseCase,
+    private readonly getUserProfileUseCase: GetUserProfileUseCase,
+  ) { }
+
+  @Get('profile')
+  @ApiOperation({ summary: 'Get user profile' })
+  @ApiResponse({ status: 200, description: 'User profile retrieved successfully' })
+  async getProfile(@Request() req: any) {
+    const user = await this.getUserProfileUseCase.execute(req.user.id);
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      currency: user.currency,
+      language: user.language,
+      createdAt: user.createdAt,
+    };
+  }
+
+  @Patch('profile')
+  @ApiOperation({ summary: 'Update user profile (name, currency, language)' })
+  @ApiResponse({ status: 200, description: 'Profile updated successfully' })
+  async updateProfile(@Request() req: any, @Body() dto: UpdateUserProfileDto) {
+    const updatedUser = await this.updateUserProfileUseCase.execute({
+      userId: req.user.id,
+      name: dto.name,
+      currency: dto.currency,
+      language: dto.language,
+    });
+
+    return {
+      id: updatedUser.id,
+      email: updatedUser.email,
+      name: updatedUser.name,
+      currency: updatedUser.currency,
+      language: updatedUser.language,
+      message: 'Profile updated successfully',
+    };
+  }
 
   @Patch('profile/currency')
   @ApiOperation({ summary: 'Update user currency and recalculate expenses' })

--- a/apps/frontend/cypress/e2e/session-isolation.cy.ts
+++ b/apps/frontend/cypress/e2e/session-isolation.cy.ts
@@ -1,0 +1,89 @@
+describe('Session Isolation & Currency Persistence', () => {
+    beforeEach(() => {
+        cy.viewport('iphone-x');
+    });
+
+    it('should maintain distinct currency preferences between real and mocked users', () => {
+        // Login as Demo User (BRL)
+        cy.visit('/login');
+        cy.contains(/Usar conta demo|Use demo account/i).click();
+        cy.get('button[type="submit"]').click();
+
+        cy.contains(/Adicionar|Add/i).should('be.visible', { timeout: 10000 });
+
+        // Set BRL currency
+        cy.get('body').click(0, 0);
+        cy.get('[aria-label="Menu"]').click();
+        cy.contains(/Moeda|Currency/i).parent().find('button').click();
+        cy.contains('Real Brasileiro').click();
+        cy.wait(1000);
+        cy.get('body').click(0, 0);
+
+        cy.get('body').should('contain', 'R$');
+
+        // Logout
+        cy.get('[aria-label="Menu"]').click();
+        cy.contains(/Sair|Logout/i).click();
+        cy.url().should('include', '/login');
+
+
+        // Login as Mocked User (USD)
+        cy.intercept('POST', '**/auth/login', {
+            statusCode: 201,
+            body: { access_token: 'mock_token_usd_user' }
+        }).as('loginMock');
+
+        cy.intercept('GET', '**/users/profile', {
+            statusCode: 200,
+            body: {
+                id: 'user_usb',
+                name: 'John Doe',
+                email: 'john@test.com',
+                currency: 'USD',
+                language: 'en'
+            }
+        }).as('getProfileMock');
+
+        cy.intercept('GET', '**/expenses?*', {
+            body: { data: [], meta: { total: 0, page: 1, limit: 20, totalPages: 1 } }
+        }).as('getExpensesMock');
+
+        cy.intercept('GET', '**/expenses/counts/periods', {
+            body: { today: 0, thisWeek: 0, thisMonth: 0, thisYear: 0, allTime: 0 }
+        }).as('getCountsMock');
+
+        cy.get('input[id="email"]').clear().type('john@test.com');
+        cy.get('input[id="password"]').clear().type('password');
+        cy.get('button[type="submit"]').click();
+
+        cy.wait('@loginMock');
+        cy.wait('@getProfileMock');
+
+        cy.contains(/Adicionar|Add/i).should('be.visible');
+
+        cy.get('[aria-label="Menu"]').click();
+        cy.contains(/Moeda|Currency/i).parent().should('contain', '$');
+        cy.get('body').click(0, 0);
+
+        // Logout
+        cy.get('[aria-label="Menu"]').click();
+        cy.contains(/Sair|Logout/i).click();
+        cy.url().should('include', '/login');
+
+
+        // Login as Demo User Again (verify BRL persistence)
+        cy.intercept('POST', '**/auth/login', (req) => req.continue()).as('loginReal');
+        cy.intercept('GET', '**/users/profile', (req) => req.continue()).as('getProfileReal');
+        cy.intercept('GET', '**/expenses?*', (req) => req.continue()).as('getExpensesReal');
+        cy.intercept('GET', '**/expenses/counts/periods', (req) => req.continue());
+
+        cy.contains(/Usar conta demo|Use demo account/i).click();
+        cy.get('button[type="submit"]').click();
+
+        cy.wait('@loginReal');
+
+        cy.contains(/Adicionar|Add/i).should('be.visible');
+        cy.get('[aria-label="Menu"]').click();
+        cy.contains(/Moeda|Currency/i).parent().should('contain', 'R$');
+    });
+});

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -9,45 +9,48 @@ import { CategoriesPage } from '@presentation/pages/CategoriesPage';
 import { ProtectedRoute } from '@presentation/components/auth/ProtectedRoute';
 import { CurrencyProvider } from '@application/contexts/CurrencyContext';
 import { LanguageProvider } from '@application/contexts/LanguageContext';
+import { AuthProvider } from '@application/contexts/AuthContext';
 
 function App() {
     return (
         <QueryClientProvider client={queryClient}>
-            <LanguageProvider>
-                <CurrencyProvider>
-                    <BrowserRouter>
-                        <Routes>
-                            <Route path="/login" element={<LoginPage />} />
-                            <Route
-                                path="/"
-                                element={
-                                    <ProtectedRoute>
-                                        <DashboardPage />
-                                    </ProtectedRoute>
-                                }
-                            />
-                            <Route
-                                path="/analytics"
-                                element={
-                                    <ProtectedRoute>
-                                        <AnalyticsPage />
-                                    </ProtectedRoute>
-                                }
-                            />
-                            <Route
-                                path="/categories"
-                                element={
-                                    <ProtectedRoute>
-                                        <CategoriesPage />
-                                    </ProtectedRoute>
-                                }
-                            />
-                            <Route path="*" element={<Navigate to="/" replace />} />
-                        </Routes>
-                    </BrowserRouter>
-                    {/* <ReactQueryDevtools initialIsOpen={false} /> */}
-                </CurrencyProvider>
-            </LanguageProvider>
+            <AuthProvider>
+                <LanguageProvider>
+                    <CurrencyProvider>
+                        <BrowserRouter>
+                            <Routes>
+                                <Route path="/login" element={<LoginPage />} />
+                                <Route
+                                    path="/"
+                                    element={
+                                        <ProtectedRoute>
+                                            <DashboardPage />
+                                        </ProtectedRoute>
+                                    }
+                                />
+                                <Route
+                                    path="/analytics"
+                                    element={
+                                        <ProtectedRoute>
+                                            <AnalyticsPage />
+                                        </ProtectedRoute>
+                                    }
+                                />
+                                <Route
+                                    path="/categories"
+                                    element={
+                                        <ProtectedRoute>
+                                            <CategoriesPage />
+                                        </ProtectedRoute>
+                                    }
+                                />
+                                <Route path="*" element={<Navigate to="/" replace />} />
+                            </Routes>
+                        </BrowserRouter>
+                        {/* <ReactQueryDevtools initialIsOpen={false} /> */}
+                    </CurrencyProvider>
+                </LanguageProvider>
+            </AuthProvider>
         </QueryClientProvider>
     );
 }

--- a/apps/frontend/src/application/contexts/AuthContext.tsx
+++ b/apps/frontend/src/application/contexts/AuthContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { localStorageService } from '../../infrastructure/storage/local-storage';
+
+interface AuthContextType {
+    userToken: string | null;
+    setUserToken: (token: string | null) => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [userToken, setUserToken] = useState<string | null>(() => {
+        return localStorageService.getToken();
+    });
+
+    return (
+        <AuthContext.Provider value={{ userToken, setUserToken }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuthContext = () => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error('useAuthContext must be used within AuthProvider');
+    }
+    return context;
+};

--- a/apps/frontend/src/application/contexts/LanguageContext.tsx
+++ b/apps/frontend/src/application/contexts/LanguageContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { createContext, useContext, useState, ReactNode } from 'react';
 import { LanguageCode, translations, Translations } from '@domain/types/language.types';
+import { userService } from '../services/user.service';
 
 interface LanguageContextType {
     language: LanguageCode;
@@ -15,14 +16,16 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
         return (saved as LanguageCode) || 'pt';
     });
 
-    const setLanguage = (newLanguage: LanguageCode) => {
-        setLanguageState(newLanguage);
-        localStorage.setItem('selected_language', newLanguage);
-    };
+    const setLanguage = async (newLanguage: LanguageCode) => {
+        try {
+            await userService.updateProfile({ language: newLanguage });
 
-    useEffect(() => {
-        localStorage.setItem('selected_language', language);
-    }, [language]);
+            setLanguageState(newLanguage);
+            localStorage.setItem('selected_language', newLanguage);
+        } catch (error) {
+            console.error('Failed to update language:', error);
+        }
+    };
 
     const t = translations[language];
 

--- a/apps/frontend/src/application/hooks/useAuth.ts
+++ b/apps/frontend/src/application/hooks/useAuth.ts
@@ -1,20 +1,26 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { LoginDto } from '@domain/interfaces/auth.interface';
 import { authService } from '../services/auth.service';
+import { localStorageService } from '../../infrastructure/storage/local-storage';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useAuthContext } from '../contexts/AuthContext';
 
 export const useAuth = () => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const { t } = useLanguage();
+    const { setUserToken } = useAuthContext();
 
     const login = async (credentials: LoginDto): Promise<void> => {
         setLoading(true);
         setError(null);
         try {
             await authService.login(credentials);
+            setUserToken(localStorageService.getToken());
             navigate('/');
         } catch {
             setError(t.auth.invalidCredentials);
@@ -24,7 +30,13 @@ export const useAuth = () => {
     };
 
     const logout = (): void => {
+        queryClient.clear();
+
+        localStorageService.clearAll();
+        setUserToken(null);
+
         authService.logout();
+
         navigate('/login');
     };
 

--- a/apps/frontend/src/application/hooks/useExpenses.ts
+++ b/apps/frontend/src/application/hooks/useExpenses.ts
@@ -5,7 +5,7 @@ import { expenseService, DateFilters, UpdateExpenseData } from '../services/expe
 import { useCurrency } from '../contexts/CurrencyContext';
 
 export const useExpenses = () => {
-    const { currency } = useCurrency();
+    const { currency, isLoadingInitial } = useCurrency();
     const queryClient = useQueryClient();
 
     const [page, setPage] = useState(1);
@@ -24,6 +24,7 @@ export const useExpenses = () => {
         queryKey,
         queryFn: () => expenseService.listExpenses(page, limit, dateFilters, sortOrder),
         placeholderData: keepPreviousData,
+        enabled: !isLoadingInitial,
         staleTime: 1000 * 60,
         refetchInterval: (query) => {
             const data = query.state.data?.data;
@@ -92,7 +93,7 @@ export const useExpenses = () => {
     return {
         expenses,
         meta,
-        loading: isLoading || createMutation.isPending || updateMutation.isPending || deleteMutation.isPending,
+        loading: isLoading || isLoadingInitial || createMutation.isPending || updateMutation.isPending || deleteMutation.isPending,
         error,
         dateFilters,
         sortOrder,

--- a/apps/frontend/src/application/hooks/useUserProfile.ts
+++ b/apps/frontend/src/application/hooks/useUserProfile.ts
@@ -1,0 +1,21 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { userService, UserProfile, UpdateProfileData } from '../services/user.service';
+
+export function useUserProfile() {
+    return useQuery<UserProfile>({
+        queryKey: ['user', 'profile'],
+        queryFn: () => userService.getProfile(),
+        staleTime: 5 * 60 * 1000,
+    });
+}
+
+export function useUpdateProfile() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: UpdateProfileData) => userService.updateProfile(data),
+        onSuccess: (updatedUser) => {
+            queryClient.setQueryData(['user', 'profile'], updatedUser);
+        },
+    });
+}

--- a/apps/frontend/src/application/services/user.service.ts
+++ b/apps/frontend/src/application/services/user.service.ts
@@ -1,7 +1,39 @@
 import { apiClient } from '../../infrastructure/http/axios-client';
 import { CurrencyCode } from '@domain/types/currency.types';
 
+export interface UserProfile {
+    id: string;
+    email: string;
+    name: string;
+    currency: CurrencyCode;
+    language: string;
+    createdAt: string;
+}
+
+export interface UpdateProfileData {
+    name?: string;
+    currency?: CurrencyCode;
+    language?: string;
+}
+
 export const userService = {
+    getProfile: async (): Promise<UserProfile> => {
+        const response = await apiClient.get<UserProfile>('/users/profile');
+        return response;
+    },
+
+    updateProfile: async (data: UpdateProfileData): Promise<UserProfile> => {
+        const response = await apiClient.patch<UserProfile>('/users/profile', data);
+        return {
+            id: response.id,
+            email: response.email,
+            name: response.name,
+            currency: response.currency,
+            language: response.language,
+            createdAt: response.createdAt,
+        };
+    },
+
     updateCurrency: async (currency: CurrencyCode): Promise<void> => {
         await apiClient.patch('/users/profile/currency', { currency });
     },

--- a/apps/frontend/src/infrastructure/storage/local-storage.ts
+++ b/apps/frontend/src/infrastructure/storage/local-storage.ts
@@ -14,6 +14,12 @@ class LocalStorageService {
     isAuthenticated(): boolean {
         return !!this.getToken();
     }
+
+    clearAll(): void {
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('selected_currency');
+        localStorage.removeItem('selected_language');
+    }
 }
 
 export const localStorageService = new LocalStorageService();


### PR DESCRIPTION
## What's New
- Fixed race condition causing incorrect currency display on login
- Implemented reactive AuthContext to properly trigger currency preference loading
- Added `isLoadingInitial` flag to block queries until backend state is ready
- Isolated session state by enforcing backend as single source of truth for currency
- Added `useUserProfile` hook for centralized profile state management
- Backend self-healing logic to correct stale/converted expense amounts
- Created [ARCHITECTURE.md](cci:7://file:///home/bruna/Dev/projects/smart-expense-analyzer/ARCHITECTURE.md:0:0-0:0) documenting state management design decisions
- Added E2E regression test ([session-isolation.cy.ts](cci:7://file:///home/bruna/Dev/projects/smart-expense-analyzer/apps/frontend/cypress/e2e/session-isolation.cy.ts:0:0-0:0)) for multi-user currency isolation

## Why
Two critical bugs were identified:
1. **Currency Display Bug**: After login, expenses showed in the wrong currency (e.g., BRL values displayed as USD) due to a race condition where `useExpenses` fetched data before the user's currency preference was loaded from the backend.
2. **Session Leakage**: Switching between users with different currency preferences caused state bleeding via `localStorage`, showing the previous user's currency selection.

The root cause was reliance on `localStorage` as a source of truth instead of the backend user profile. The fix enforces that for authenticated users, currency preferences **always** come from the backend, with `localStorage` only used as a fallback for unauthenticated states.

## Testing
- [x] Unit tests added/updated - All 88 backend tests passing
- [x] Frontend unit tests passing (1/1)
- [x] E2E test: [session-isolation.cy.ts](cci:7://file:///home/bruna/Dev/projects/smart-expense-analyzer/apps/frontend/cypress/e2e/session-isolation.cy.ts:0:0-0:0) validates currency persistence across user sessions
- [x] Manual test: Login as Demo (BRL) → Logout → Login as different user (USD) → Logout → Login as Demo again, verify BRL persists without leakage

## Checklist
- [x] Code follows Clean Architecture principles
- [x] Backend handles currency conversion with self-healing for stale data
- [x] Frontend blocks data fetches until backend state is loaded (`isLoadingInitial`)
- [x] `localStorage.clearAll()` on logout prevents session bleeding
- [x] ESLint passing (3 fast-refresh warnings only, unrelated to this PR)
- [x] Architecture documented in `ARCHITECTURE.md`